### PR TITLE
Add generate-test command

### DIFF
--- a/README-task-master.md
+++ b/README-task-master.md
@@ -86,6 +86,9 @@ task-master next
 
 # Generate task files
 task-master generate
+
+# Generate Jest tests
+task-master generate-test --id=1
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ task-master next
 
 # Generate task files
 task-master generate
+
+# Generate Jest tests for a task
+task-master generate-test --id=1
 ```
 
 ## Documentation

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -89,6 +89,16 @@ Unlike the `update-task` command which replaces task information, the `update-su
 task-master generate
 ```
 
+## Generate Jest Tests
+
+```bash
+# Generate tests for a specific task
+task-master generate-test --id=<id>
+
+# Generate tests for all tasks including subtasks
+task-master generate-test --all --with-subtasks
+```
+
 ## Set Task Status
 
 ```bash

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -27,10 +27,11 @@ import {
 	removeSubtask,
 	analyzeTaskComplexity,
 	updateTaskById,
-	updateSubtaskById,
-	removeTask,
-	findTaskById,
-	taskExists
+        updateSubtaskById,
+        removeTask,
+        findTaskById,
+        taskExists,
+        generateTest
 } from './task-manager.js';
 
 import {
@@ -1864,8 +1865,8 @@ function registerCommands(programInstance) {
 	}
 
 	// remove-task command
-	programInstance
-		.command('remove-task')
+        programInstance
+                .command('remove-task')
 		.description('Remove one or more tasks or subtasks permanently')
 		.description('Remove one or more tasks or subtasks permanently')
 		.option(
@@ -1992,7 +1993,60 @@ function registerCommands(programInstance) {
 								chalk.white.bold(`  Task ${id}: ${task.title || '(no title)'}`)
 							);
 						}
-					});
+                });
+
+        // generate-test command
+        programInstance
+                .command('generate-test')
+                .description('Generate Jest tests for tasks using AI')
+                .option('-i, --id <id>', 'Task ID to generate tests for')
+                .option('-a, --all', 'Generate tests for all tasks')
+                .option('--with-subtasks', 'Include subtasks in prompt')
+                .option('-p, --prompt <text>', 'Additional context for test generation')
+                .option('-f, --file <file>', 'Path to the tasks file', 'tasks/tasks.json')
+                .action(async (options) => {
+                        const tasksPath = options.file;
+                        const withSubtasks = options.withSubtasks || false;
+                        const extraPrompt = options.prompt || '';
+
+                        if (!options.id && !options.all) {
+                                const answers = await inquirer.prompt([
+                                        {
+                                                type: 'input',
+                                                name: 'id',
+                                                message: 'Enter task ID'
+                                        }
+                                ]);
+                                options.id = answers.id;
+                        }
+
+                        try {
+                                if (options.all) {
+                                        const data = readJSON(tasksPath);
+                                        if (!data || !data.tasks) {
+                                                throw new Error('No tasks found');
+                                        }
+                                        for (const t of data.tasks) {
+                                                await generateTest({
+                                                        tasksPath,
+                                                        id: t.id,
+                                                        includeSubtasks: withSubtasks,
+                                                        prompt: extraPrompt
+                                                });
+                                        }
+                                } else {
+                                        await generateTest({
+                                                tasksPath,
+                                                id: options.id,
+                                                includeSubtasks: withSubtasks,
+                                                prompt: extraPrompt
+                                        });
+                                }
+                        } catch (error) {
+                                console.error(chalk.red(`Error generating tests: ${error.message}`));
+                                process.exit(1);
+                        }
+                });
 
 					if (totalSubtasksToDelete > 0) {
 						console.log(

--- a/scripts/modules/task-manager.js
+++ b/scripts/modules/task-manager.js
@@ -23,6 +23,7 @@ import updateSubtaskById from './task-manager/update-subtask-by-id.js';
 import removeTask from './task-manager/remove-task.js';
 import taskExists from './task-manager/task-exists.js';
 import isTaskDependentOn from './task-manager/is-task-dependent.js';
+import generateTest from './task-manager/generate-test.js';
 import { readComplexityReport } from './utils.js';
 // Export task manager functions
 export {
@@ -42,9 +43,10 @@ export {
 	removeSubtask,
 	findNextTask,
 	analyzeTaskComplexity,
-	removeTask,
-	findTaskById,
-	taskExists,
-	isTaskDependentOn,
-	readComplexityReport
+        removeTask,
+        findTaskById,
+        taskExists,
+        isTaskDependentOn,
+        readComplexityReport,
+        generateTest
 };

--- a/scripts/modules/task-manager/generate-test.js
+++ b/scripts/modules/task-manager/generate-test.js
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import path from 'path';
+
+import { readJSON, log } from '../utils.js';
+import { startLoadingIndicator, stopLoadingIndicator } from '../ui.js';
+import { generateTextService } from '../ai-services-unified.js';
+import { getDebugFlag } from '../config-manager.js';
+
+function padId(id) {
+    return id.toString().padStart(3, '0');
+}
+
+/**
+ * Generate a Jest test file for a task using the AI service.
+ * @param {object} params - Options for generation
+ * @param {string} params.tasksPath - Path to tasks.json
+ * @param {number|string} params.id - Task ID
+ * @param {boolean} [params.includeSubtasks=false] - Include subtasks in prompt
+ * @param {string} [params.prompt=''] - Additional prompt context
+ * @param {object} [params.context={}] - Execution context (session, mcpLog)
+ */
+async function generateTest({ tasksPath, id, includeSubtasks = false, prompt = '', context = {} }) {
+    const { session, mcpLog, projectRoot: ctxRoot } = context;
+    const outputFormat = mcpLog ? 'json' : 'text';
+    const projectRoot = ctxRoot || path.dirname(path.dirname(tasksPath));
+
+    const logger = mcpLog || {
+        info: (msg) => log('info', msg),
+        error: (msg) => log('error', msg)
+    };
+
+    const data = readJSON(tasksPath);
+    if (!data || !Array.isArray(data.tasks)) {
+        throw new Error(`Invalid tasks data in ${tasksPath}`);
+    }
+
+    const taskId = parseInt(id, 10);
+    const task = data.tasks.find((t) => t.id === taskId);
+    if (!task) {
+        throw new Error(`Task ${id} not found`);
+    }
+
+    let taskPrompt = `Generate a Jest test file for the following task.\nTask ${task.id}: ${task.title}\n${task.description}\n${task.details || ''}`;
+    if (includeSubtasks && Array.isArray(task.subtasks) && task.subtasks.length > 0) {
+        taskPrompt += `\nSubtasks:\n` + task.subtasks.map((st) => `${st.id}. ${st.title} - ${st.description}`).join('\n');
+    }
+    if (prompt) {
+        taskPrompt += `\nAdditional Context: ${prompt}`;
+    }
+
+    const systemPrompt = 'You are an AI developer assistant. Provide only valid Jest test code.';
+
+    logger.info(`Generating test for task ${task.id}`);
+    const indicator = startLoadingIndicator ? startLoadingIndicator('Generating tests...') : null;
+    let aiResponse;
+    try {
+        aiResponse = await generateTextService({
+            prompt: taskPrompt,
+            systemPrompt,
+            role: 'main',
+            session,
+            projectRoot,
+            commandName: 'generate-test',
+            outputType: outputFormat
+        });
+    } finally {
+        if (indicator) stopLoadingIndicator(indicator);
+    }
+
+    let testContent = '';
+    if (typeof aiResponse?.mainResult === 'string') {
+        testContent = aiResponse.mainResult;
+    } else if (typeof aiResponse === 'string') {
+        testContent = aiResponse;
+    }
+
+    const outputDir = path.join(projectRoot, 'tests', 'generated');
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+    }
+    const fileName = `task_${padId(task.id)}.test.ts`;
+    const filePath = path.join(outputDir, fileName);
+    fs.writeFileSync(filePath, testContent);
+
+    logger.info(`Test written to ${filePath}`);
+    return filePath;
+}
+
+export default generateTest;

--- a/tests/unit/generate-test.test.js
+++ b/tests/unit/generate-test.test.js
@@ -1,0 +1,53 @@
+import { jest } from '@jest/globals';
+
+// Mock fs before import
+jest.mock('fs', () => ({
+    existsSync: jest.fn(() => false),
+    mkdirSync: jest.fn(),
+    writeFileSync: jest.fn()
+}));
+
+const mockGenerateTextService = jest.fn();
+
+jest.unstable_mockModule('../../scripts/modules/ai-services-unified.js', () => ({
+    generateTextService: mockGenerateTextService
+}));
+
+const mockReadJSON = jest.fn();
+jest.unstable_mockModule('../../scripts/modules/utils.js', () => ({
+    readJSON: mockReadJSON,
+    log: jest.fn()
+}));
+
+let generateTest;
+let fs;
+
+beforeAll(async () => {
+    generateTest = (await import('../../scripts/modules/task-manager/generate-test.js')).default;
+    fs = await import('fs');
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockReadJSON.mockReturnValue({
+        tasks: [
+            { id: 1, title: 'Test', description: 'Desc', details: '' }
+        ]
+    });
+    mockGenerateTextService.mockResolvedValue({ mainResult: 'test code' });
+});
+
+describe('generateTest', () => {
+    test('calls AI service and writes file', async () => {
+        await generateTest({ tasksPath: 'tasks.json', id: 1 });
+        expect(mockGenerateTextService).toHaveBeenCalled();
+        expect(fs.writeFileSync).toHaveBeenCalled();
+    });
+
+    test('throws for missing task', async () => {
+        mockReadJSON.mockReturnValue({ tasks: [] });
+        await expect(
+            generateTest({ tasksPath: 'tasks.json', id: 5 })
+        ).rejects.toThrow('Task 5 not found');
+    });
+});


### PR DESCRIPTION
## Summary
- implement `generate-test` command
- generate Jest test with AI service
- expose new task manager function
- document command usage
- provide unit test for generate-test module

## Testing
- `npm test` *(fails: Cannot find module '/workspace/claude-task-master/node_modules/.bin/jest')*