### PR TITLE
Add ts-jest config and build step for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ dev-debug.log
 
 # NPMRC
 .npmrc
+claude-task-master/

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,11 +14,19 @@ export default {
 	// A list of paths to directories that Jest should use to search for files in
 	roots: ['<rootDir>/tests'],
 
-	// The glob patterns Jest uses to detect test files
-	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
+        // The glob patterns Jest uses to detect test files
+        testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).[jt]s'],
 
-	// Transform files
-	transform: {},
+        // Use ts-jest for TypeScript files
+        preset: 'ts-jest',
+        transform: {
+                '^.+\\.(ts|tsx)$': [
+                        'ts-jest',
+                        {
+                                tsconfig: 'tsconfig.json'
+                        }
+                ]
+        },
 
 	// Disable transformations for node_modules
 	transformIgnorePatterns: ['/node_modules/'],

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
 		"task-master-ai": "mcp-server/server.js"
 	},
 	"scripts": {
-		"test": "node --experimental-vm-modules node_modules/.bin/jest",
-		"test:fails": "node --experimental-vm-modules node_modules/.bin/jest --onlyFailures",
-		"test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
-		"test:coverage": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
+                "build": "tsup",
+                "test": "npm run build && node --experimental-vm-modules node_modules/.bin/jest",
+                "test:fails": "npm run build && node --experimental-vm-modules node_modules/.bin/jest --onlyFailures",
+                "test:watch": "npm run build && node --experimental-vm-modules node_modules/.bin/jest --watch",
+                "test:coverage": "npm run build && node --experimental-vm-modules node_modules/.bin/jest --coverage",
 		"test:e2e": "./tests/e2e/run_e2e.sh",
 		"test:e2e-report": "./tests/e2e/run_e2e.sh --analyze-log",
 		"prepare": "chmod +x bin/task-master.js mcp-server/server.js",
@@ -102,12 +103,15 @@
 		"execa": "^8.0.1",
 		"ink": "^5.0.1",
 		"jest": "^29.7.0",
-		"jest-environment-node": "^29.7.0",
-		"mock-fs": "^5.5.0",
-		"node-fetch": "^3.3.2",
-		"prettier": "^3.5.3",
-		"react": "^18.3.1",
-		"supertest": "^7.1.0",
-		"tsx": "^4.16.2"
-	}
+                "jest-environment-node": "^29.7.0",
+                "mock-fs": "^5.5.0",
+                "node-fetch": "^3.3.2",
+                "prettier": "^3.5.3",
+                "react": "^18.3.1",
+                "supertest": "^7.1.0",
+                "tsx": "^4.16.2",
+                "ts-jest": "^29.1.1",
+                "tsup": "^8.5.0",
+                "typescript": "^5.8.3"
+        }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "declaration": true,
+    "outDir": "dist",
+    "allowJs": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/**/*.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  outDir: 'dist',
+});


### PR DESCRIPTION
## Summary
- configure Jest to transform TypeScript using ts-jest
- add build step with tsup before running tests
- include ts-jest, tsup and TypeScript dev deps
- add project tsconfig and tsup config
- ignore nested project directory

## Testing
- `npm test` *(fails: tsup not found)*